### PR TITLE
refactor: 移除 NotificationsPage 中的 Page 後綴

### DIFF
--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -1,10 +1,10 @@
-import NotificationList from "@/components/client/notifications/NotificationList";
+import Notification from "@/components/server/Notification";
 
-export default function NotificationsPage() {
+export default function Notifications() {
   return (
     <div className="container mx-auto py-8">
       <h1 className="text-2xl font-bold mb-6">通知中心</h1>
-      <NotificationList />
+      <Notification />
     </div>
   );
 }


### PR DESCRIPTION
## 重構：優化通知頁面組件結構

### 變更內容
- 移除 `NotificationsPage` 中的 `Page` 後綴，改為 `Notifications`
- 整合 `Notification` Server Component 進行數據預取

### 技術細節
- 使用 Server Component 預取通知數據
- 通過 `HydrationBoundary` 將數據傳遞給客戶端
- 保持客戶端狀態管理的靈活性

### 相關 Issue
Closes #1

### 測試步驟
1. 訪問 `/notifications` 頁面
2. 確認頁面標題顯示正常
3. 確認通知列表加載正常
4. 確認客戶端交互（如標記已讀）功能正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the notifications page to use a new server-rendered notifications component, replacing the previous client-side component. The overall layout and heading remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->