### PR TITLE
style: 限制標題的行寬與行數

### DIFF
--- a/src/components/client/notifications/NotificationItem.tsx
+++ b/src/components/client/notifications/NotificationItem.tsx
@@ -30,7 +30,9 @@ export default function NotificationItem({
     <div className="border rounded-lg p-4 space-y-2 bg-white shadow">
       <div className="flex justify-between items-end">
         <div>
-          <p className="font-medium text-lg">{subject.title}</p>
+          <h2 className="font-semibold text-lg w-[40ch] line-clamp-2">
+            {subject.title}
+          </h2>
           <p className="text-gray-500 text-sm">{subject.type}</p>
           <p className="text-gray-400 text-xs">
             {updated_at ? new Date(updated_at).toLocaleString() : ""}
@@ -49,11 +51,11 @@ export default function NotificationItem({
             </button>
           </div>
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex gap-6">
           {subject.url && (
             <button
               onClick={() => onShowContent(subject.url, subject.title)}
-              className="bg-blue-600 text-white rounded px-3 py-1 font-semibold hover:bg-blue-700 transition flex items-center justify-center cursor-pointer"
+              className="bg-blue-600 text-white rounded px-3 py-1 font-semibold hover:bg-blue-700 transition cursor-pointer"
             >
               查看內容
             </button>


### PR DESCRIPTION
## 主要改動
- 限制通知標題（如 PR 標題）單行顯示字數，避免過長導致版面破壞
- 增加斷行、ellipsis 或其他樣式優化，提升閱讀體驗

## 影響範圍
- 通知列表

## 測試重點
- 標題過長時是否正確截斷或顯示省略號
- 不影響原有通知功能與互動

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the appearance of notification titles for better readability and consistency.
  - Updated the layout of action buttons for a more streamlined horizontal arrangement.
  - Simplified button styling for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->