### PR TITLE
fix: 修正通知 webUrl 產生邏輯，正確導向 PR、Issue 或 Commit 頁面

### DIFF
--- a/src/adapters/notificationAdapter.ts
+++ b/src/adapters/notificationAdapter.ts
@@ -1,5 +1,27 @@
 import type { GitHubNotification } from "@/types/notification";
 import { Notification } from "@/types/zod/notification";
+function getWebUrl(notification: GitHubNotification) {
+  const { subject, repository } = notification;
+  const repoFullName = repository.full_name;
+  const { url: apiUrl, type } = subject;
+
+  if (!apiUrl || !type) return `https://github.com/${repoFullName}`;
+
+  const numberMatch = apiUrl.match(/\/(\d+)$/);
+  const shaMatch = apiUrl.match(/\/commits\/([a-f0-9]+)$/);
+
+  if (type === "PullRequest" && numberMatch) {
+    return `https://github.com/${repoFullName}/pull/${numberMatch[1]}`;
+  }
+  if (type === "Issue" && numberMatch) {
+    return `https://github.com/${repoFullName}/issues/${numberMatch[1]}`;
+  }
+  if (type === "Commit" && shaMatch) {
+    return `https://github.com/${repoFullName}/commit/${shaMatch[1]}`;
+  }
+
+  return `https://github.com/${repoFullName}`;
+}
 export default function notificationAdapter(
   notification: GitHubNotification
 ): Notification {
@@ -13,6 +35,6 @@ export default function notificationAdapter(
     },
     updated_at: notification.updated_at,
     url: notification.url,
-    webUrl: `https://github.com/${notification.repository.full_name}`,
+    webUrl: getWebUrl(notification),
   };
 }


### PR DESCRIPTION
### 主要改動
- 根據通知類型（PullRequest、Issue、Commit）與 `subject.url` 產生正確的 GitHub 頁面連結
- 避免所有通知都只導向 repository 首頁
- 提升使用者點擊通知的體驗

### 測試重點
- 點擊通知時，能正確導向對應的 PR、Issue 或 Commit 頁面
- 其他通知類型 fallback 至 repo 首頁

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notification links now direct users to the specific Pull Request, Issue, or Commit related to the notification, instead of always pointing to the repository main page. This provides more precise navigation from notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->