### PR TITLE
refactor: Notifications tree

### DIFF
--- a/src/components/client/notifications/NotificationItem.tsx
+++ b/src/components/client/notifications/NotificationItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import Link from "next/link";
 
 type NotificationItemProps = {
@@ -14,63 +14,118 @@ type NotificationItemProps = {
     url: string;
     webUrl: string;
   };
-  onMarkAsRead: (id: string, unread: boolean) => void;
-  markAsReadPending: boolean;
+  onMark: (id: string, unread: boolean) => void;
+  pending: boolean;
   onShowContent: (apiUrl: string, title: string) => void;
 };
 
 export default function NotificationItem({
   notification,
-  onMarkAsRead,
-  markAsReadPending,
+  onMark,
+  pending,
   onShowContent,
 }: NotificationItemProps) {
   const { id, subject, updated_at, unread, webUrl } = notification;
 
   return (
     <div className="border rounded-lg p-4 space-y-2 bg-white shadow">
-      <div className="flex justify-between items-end">
-        <div>
-          <h2 className="font-semibold text-lg w-[40ch] line-clamp-2">
-            {subject.title}
-          </h2>
-          <p className="text-gray-500 text-sm">{subject.type}</p>
-          <p className="text-gray-400 text-xs">
-            {updated_at ? new Date(updated_at).toLocaleString() : ""}
-          </p>
-          <div className="flex items-center gap-4 mt-2">
-            <button
-              onClick={() => onMarkAsRead(id, unread)}
-              disabled={!unread || markAsReadPending}
-              className={`px-2 py-1 rounded text-xs font-semibold border ${
-                !unread
-                  ? "bg-green-100 text-green-700 cursor-not-allowed opacity-50"
-                  : "bg-yellow-100 text-yellow-700"
-              } ${markAsReadPending ? "opacity-50 cursor-not-allowed" : ""}`}
-            >
-              {markAsReadPending ? "處理中..." : !unread ? "已讀" : "未讀"}
-            </button>
-          </div>
-        </div>
-        <div className="flex gap-6">
-          {subject.url && (
-            <button
-              onClick={() => onShowContent(subject.url, subject.title)}
-              className="bg-blue-600 text-white rounded px-3 py-1 font-semibold hover:bg-blue-700 transition cursor-pointer"
-            >
-              查看內容
-            </button>
-          )}
-          <Link
-            href={webUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline text-blue-600 font-semibold px-2 py-1"
-          >
-            前往 GitHub
-          </Link>
-        </div>
+      <NotificationItem.Info subject={subject} updated_at={updated_at} />
+
+      <div className="flex justify-between">
+        <NotificationItem.Mark
+          id={id}
+          unread={unread}
+          pending={pending}
+          onMark={onMark}
+        />
+        <NotificationItem.Actions
+          subject={subject}
+          webUrl={webUrl}
+          onShowContent={onShowContent}
+        />
       </div>
     </div>
   );
 }
+
+NotificationItem.Info = memo(
+  ({
+    subject,
+    updated_at,
+  }: {
+    subject: { title: string; type: string };
+    updated_at: string;
+  }) => {
+    return (
+      <div>
+        <h2 className="font-semibold text-lg w-[40ch] line-clamp-2">
+          {subject.title}
+        </h2>
+        <p className="text-gray-500 text-sm">{subject.type}</p>
+        <p className="text-gray-400 text-xs">
+          {updated_at ? new Date(updated_at).toLocaleString() : ""}
+        </p>
+      </div>
+    );
+  }
+);
+NotificationItem.Mark = memo(
+  ({
+    id,
+    unread,
+    pending,
+    onMark,
+  }: {
+    id: string;
+    unread: boolean;
+    pending: boolean;
+    onMark: (id: string, unread: boolean) => void;
+  }) => {
+    console.log("render");
+    return (
+      <button
+        onClick={() => onMark(id, unread)}
+        disabled={!unread || pending}
+        className={`px-2 py-1 rounded text-xs font-semibold border ${
+          !unread
+            ? "bg-green-100 text-green-700 cursor-not-allowed opacity-50"
+            : "bg-yellow-100 text-yellow-700"
+        } ${pending ? "opacity-50 cursor-not-allowed" : ""}`}
+      >
+        {pending ? "處理中..." : !unread ? "已讀" : "未讀"}
+      </button>
+    );
+  }
+);
+NotificationItem.Actions = memo(
+  ({
+    subject,
+    webUrl,
+    onShowContent,
+  }: {
+    subject: { url: string; title: string };
+    webUrl: string;
+    onShowContent: (url: string, title: string) => void;
+  }) => {
+    return (
+      <div className="flex gap-6">
+        {subject.url && (
+          <button
+            onClick={() => onShowContent(subject.url, subject.title)}
+            className="bg-blue-600 text-white rounded px-3 py-1 font-semibold hover:bg-blue-700 transition cursor-pointer"
+          >
+            查看內容
+          </button>
+        )}
+        <Link
+          href={webUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline text-blue-600 font-semibold px-2 py-1"
+        >
+          前往 GitHub
+        </Link>
+      </div>
+    );
+  }
+);

--- a/src/components/client/notifications/OverlayModal.tsx
+++ b/src/components/client/notifications/OverlayModal.tsx
@@ -1,13 +1,13 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, memo } from "react";
 
 type OverlayModalProps = {
-  title?: string;
+  title: string;
+  onClose: () => void;
   children: React.ReactNode;
-  onClose?: () => void;
 };
 
 const OverlayModal = forwardRef<HTMLDialogElement, OverlayModalProps>(
-  ({ title, children, onClose }, ref) => (
+  ({ title, onClose, children }, ref) => (
     <dialog
       ref={ref}
       aria-modal="true"
@@ -29,11 +29,9 @@ const OverlayModal = forwardRef<HTMLDialogElement, OverlayModalProps>(
         >
           x
         </button>
-        {title && (
-          <h2 id="modal-title" className="text-lg font-bold mb-4">
-            {title}
-          </h2>
-        )}
+        <h2 id="modal-title" className="text-lg font-bold mb-4">
+          {title}
+        </h2>
         <div id="modal-description" className="w-full h-full p-4">
           {children}
         </div>
@@ -42,4 +40,4 @@ const OverlayModal = forwardRef<HTMLDialogElement, OverlayModalProps>(
   )
 );
 
-export default OverlayModal;
+export default memo(OverlayModal);

--- a/src/components/client/notifications/OverlayModalContent.tsx
+++ b/src/components/client/notifications/OverlayModalContent.tsx
@@ -1,0 +1,22 @@
+import ReactMarkdown from "react-markdown";
+import { MarkdownComponents } from "./MarkdownComponents";
+import Spinner from "@/components/client/ui/Spinner";
+import { notificationDetailQueryOptions } from "@/data/query-options/notifications";
+import { useQuery } from "@tanstack/react-query";
+
+const OverlayModalContent = ({ id }: { id: string | null }) => {
+  const { data, status } = useQuery<{ body: string }>(
+    notificationDetailQueryOptions(id)
+  );
+
+  return status === "pending" ? (
+    <Spinner />
+  ) : status === "error" ? (
+    <div className="text-red-500">載入失敗，請稍後再試。</div>
+  ) : (
+    <ReactMarkdown components={MarkdownComponents}>
+      {data?.body ?? "無詳細內容"}
+    </ReactMarkdown>
+  );
+};
+export default OverlayModalContent;

--- a/src/components/client/notifications/RepoList.tsx
+++ b/src/components/client/notifications/RepoList.tsx
@@ -5,6 +5,7 @@ import RepoNotificationSetting from "./RepoNotificationSetting";
 import NProgress from "@/lib/nprogress";
 import type { RepoWithNotifications } from "@/types/zod/notification";
 import toast from "react-hot-toast";
+import React from "react";
 export default function RepoList({
   initialData,
 }: {

--- a/src/components/client/notifications/TypeList.tsx
+++ b/src/components/client/notifications/TypeList.tsx
@@ -1,4 +1,6 @@
-export const NOTIFICATION_TYPE_LABELS: {
+import React from "react";
+import { GitHubNotificationType } from "@/types/notification";
+const NOTIFICATION_TYPE_LABELS: {
   [key: string]: string;
   value: GitHubNotificationType;
 }[] = [
@@ -10,8 +12,7 @@ export const NOTIFICATION_TYPE_LABELS: {
   { label: "Issues", value: "Issue", desc: "問題報告和功能請求相關通知" },
   { label: "Commit", value: "Commit", desc: "程式碼提交相關通知" },
 ];
-import { GitHubNotificationType } from "@/types/notification";
-import React from "react";
+
 export default function TypeList({
   types,
   onChange,

--- a/src/components/client/notifications/useDialogControl.ts
+++ b/src/components/client/notifications/useDialogControl.ts
@@ -1,10 +1,6 @@
 import { useRef, useCallback } from "react";
 
-export default function useDialogControl(): [
-  React.RefObject<HTMLDialogElement | null>,
-  () => void,
-  () => void
-] {
+export default function useDialogControl() {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
 
   const open = useCallback(() => {
@@ -17,5 +13,9 @@ export default function useDialogControl(): [
     if (dialog?.open) dialog.close();
   }, []);
 
-  return [dialogRef, open, close];
+  return {
+    ref: dialogRef,
+    open,
+    close,
+  };
 }


### PR DESCRIPTION
## `NotificationList`  定義了 `OverlayModalContent`

- `OverlayModalContent` 根據不同 id 顯示其內容
```jsx
  <OverlayModalContent id={selectedId} />
```

##  `NotificationItem` 根據 props 穩定程度拆分不同區塊
```jsx
  <NotificationItem.Info subject={subject} updated_at={updated_at} />
  <NotificationItem.Mark
     id={id}
     unread={unread}
     pending={pending}
     onMark={onMark}
  />
  <NotificationItem.Actions
    subject={subject}
    webUrl={webUrl}
    onShowContent={onShowContent}
  />
```
### Before:
NotificationItem renders: 1 次
├── Info section renders: 1 次 (不必要)
├── Mark section renders: 1 次 (必要)  
└── Actions section renders: 1 次 (不必要)
總計：4 次渲染

### After
NotificationItem renders: 0 次
├── Info section renders: 0 次 ✅
├── Mark section renders: 1 次 ✅
└── Actions section renders: 0 次 ✅  
總計：1 次渲染 (75% 減少)

--- 

**影響範圍**：前端組件
closes #20 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated modal content component for displaying notification details with improved loading and error handling.
- **Refactor**
	- Modularized the notification item display into smaller, memoized subcomponents for better UI structure.
	- Simplified and optimized modal handling and dialog control logic.
	- Improved naming consistency for props and callbacks.
- **Style**
	- Updated modal to always display a title for consistency.
- **Chores**
	- Adjusted import order and export visibility for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->